### PR TITLE
Убрал излишние поля обертки ответа

### DIFF
--- a/src/main/java/ru/vtb/vkod/exampleproject/controller/ControllerExceptionHandler.java
+++ b/src/main/java/ru/vtb/vkod/exampleproject/controller/ControllerExceptionHandler.java
@@ -17,8 +17,6 @@ public class ControllerExceptionHandler {
         log.warn(e.getMessage());
 
         return new ResponseEntity<>(ResponseWrapper.<ExampleException>builder()
-                .code(400)
-                .success(false)
                 .error(e.getClass().getName())
                 .message(e.getMessage())
                 .build(), HttpStatus.BAD_REQUEST);
@@ -29,8 +27,6 @@ public class ControllerExceptionHandler {
         log.error(e.getMessage());
 
         return new ResponseEntity<>(ResponseWrapper.<RuntimeException>builder()
-                .code(500)
-                .success(false)
                 .error(e.getClass().getName())
                 .message(e.getMessage())
                 .build(), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/ru/vtb/vkod/exampleproject/controller/ResponseWrapper.java
+++ b/src/main/java/ru/vtb/vkod/exampleproject/controller/ResponseWrapper.java
@@ -9,10 +9,6 @@ import lombok.*;
 @AllArgsConstructor
 @Builder(toBuilder = true)
 public class ResponseWrapper<T> {
-    @Builder.Default
-    private Integer code = 200;
-    @Builder.Default
-    private Boolean success = true;
     private T data;
     private String message;
     private String error;


### PR DESCRIPTION
Значения полей однозначно выводятся из статуса ответа, мне кажется дублировать их - лишняя путанца, особенно если тот же код в сообщении и в статусе будет отличаться